### PR TITLE
[FORUM-1052]Category spaces appears in the list when creating a forum

### DIFF
--- a/forum/service/src/main/java/org/exoplatform/forum/service/Category.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/Category.java
@@ -87,7 +87,15 @@ public class Category {
   public void setOwner(String owner) {
     this.owner = owner;
   }
+  
+   public String getName() {
+    return name;
+  }
 
+  public void setName(String name) {
+    this.name = name;
+  }
+  
   public String getPath() {
     return path;
   }

--- a/forum/service/src/main/java/org/exoplatform/forum/service/Category.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/Category.java
@@ -87,15 +87,7 @@ public class Category {
   public void setOwner(String owner) {
     this.owner = owner;
   }
-  
-   public String getName() {
-    return name;
-  }
 
-  public void setName(String name) {
-    this.name = name;
-  }
-  
   public String getPath() {
     return path;
   }

--- a/forum/service/src/main/java/org/exoplatform/forum/service/ForumService.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/ForumService.java
@@ -90,12 +90,12 @@ public interface ForumService extends ForumServiceLegacy {
   List<Category> getCategories();
 
   /**
-   * Gets categories in Forums without considering the category Spaces .
-   *
-   * @return Categories.
-   * @LevelAPI Platform
-   */
-  List<Category> getCategoriesForumCreation();
+  * Gets the list of categories in Forums without the category Spaces .
+  *
+  * @return Categories.
+  * @LevelAPI Platform
+  */
+  List<Category> getCategories(boolean withoutSpaces);
   
   /**
    * 

--- a/forum/service/src/main/java/org/exoplatform/forum/service/ForumService.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/ForumService.java
@@ -90,6 +90,14 @@ public interface ForumService extends ForumServiceLegacy {
   List<Category> getCategories();
 
   /**
+   * Gets categories in Forums without considering the category Spaces .
+   *
+   * @return Categories.
+   * @LevelAPI Platform
+   */
+  List<Category> getCategoriesForumCreation();
+  
+  /**
    * 
    * Gets a category by its provided Id.
    * 

--- a/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
@@ -323,7 +323,20 @@ public class ForumServiceImpl implements ForumService, Startable {
   public List<Category> getCategories() {
     return storage.getCategories();
   }
-
+  
+   /**
+   * {@inheritDoc}
+   */
+  public List<Category> getCategoriesForumCreation() {
+   List<Category> categoriesDisplay = new ArrayList<Category>();
+   List<Category> categories = storage.getCategories();
+   for(Category category : categories ){
+     if(!(category.getName().equals("spaces"))){
+        categoriesDisplay.add(category);
+      }
+    }
+   return categoriesDisplay;
+  }
   /**
    * {@inheritDoc}
    */

--- a/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/impl/ForumServiceImpl.java
@@ -327,14 +327,16 @@ public class ForumServiceImpl implements ForumService, Startable {
    /**
    * {@inheritDoc}
    */
-  public List<Category> getCategoriesForumCreation() {
+  public List<Category> getCategories(boolean withoutSpaces) {
    List<Category> categoriesDisplay = new ArrayList<Category>();
    List<Category> categories = storage.getCategories();
-   for(Category category : categories ){
-     if(!(category.getName().equals("spaces"))){
-        categoriesDisplay.add(category);
-      }
-    }
+   if(withoutSpaces) {
+     for (Category category : categories) {
+        if (!(category.getId().equals("forumCategoryspaces"))) {
+           categoriesDisplay.add(category);
+        }
+     }
+   }
    return categoriesDisplay;
   }
   /**

--- a/forum/service/src/test/java/org/exoplatform/forum/service/ForumServiceTestCase.java
+++ b/forum/service/src/test/java/org/exoplatform/forum/service/ForumServiceTestCase.java
@@ -947,7 +947,19 @@ public class ForumServiceTestCase extends BaseForumServiceTestCase {
     messageInfo = (SendMessageInfo) messages.get(2);
     assertEquals(1, messageInfo.getEmailAddresses().size());
   }
-  
+
+  public void testCategoriesList() throws Exception {
+    String cateId = Utils.CATEGORY + "spaces";
+    Category categorySpace = createCategory(cateId);
+    categorySpace.setCategoryName("spaces");
+    forumService_.saveCategory(categorySpace, true);
+    Category category = createCategory(getId(Utils.CATEGORY));
+    forumService_.saveCategory(category, true);
+    List<Category> categories = forumService_.getCategories(true);
+    assertFalse(categories.contains(categorySpace));
+    assertTrue(categories.contains(category));
+  }
+
   private Group createGroup(Group parent, String groupName) throws Exception {
     GroupHandler groupHandler = UserHelper.getGroupHandler();
     String parentId = (parent == null) ? "" : parent.getId() + "/";

--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/UICategories.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/UICategories.java
@@ -191,7 +191,7 @@ public class UICategories extends UIContainer {
 
   private List<Category> getCategoryList() throws Exception {
     try {
-      categoryList = forumService.getCategories();
+      categoryList = forumService.getCategories(true);
     } catch (Exception e) {
       categoryList = new ArrayList<Category>();
     }

--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIForumActionBar.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIForumActionBar.java
@@ -224,7 +224,7 @@ public class UIForumActionBar extends UIContainer {
   static public class AddForumActionListener extends EventListener<UIForumActionBar> {
     public void execute(Event<UIForumActionBar> event) throws Exception {
       UIForumActionBar uiActionBar = event.getSource();
-      if (uiActionBar.forumService.getCategoriesForumCreation().size() > 0) {
+      if (uiActionBar.forumService.getCategories(true).size() > 0) {
         UIForumPortlet forumPortlet = uiActionBar.getParent();
         UIPopupAction popupAction = forumPortlet.getChild(UIPopupAction.class);
         UIPopupContainer popupContainer = popupAction.createUIComponent(UIPopupContainer.class, null, null);

--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIForumActionBar.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIForumActionBar.java
@@ -224,7 +224,7 @@ public class UIForumActionBar extends UIContainer {
   static public class AddForumActionListener extends EventListener<UIForumActionBar> {
     public void execute(Event<UIForumActionBar> event) throws Exception {
       UIForumActionBar uiActionBar = event.getSource();
-      if (uiActionBar.forumService.getCategories().size() > 0) {
+      if (uiActionBar.forumService.getCategoriesForumCreation().size() > 0) {
         UIForumPortlet forumPortlet = uiActionBar.getParent();
         UIPopupAction popupAction = forumPortlet.getChild(UIPopupAction.class);
         UIPopupContainer popupContainer = popupAction.createUIComponent(UIPopupContainer.class, null, null);

--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIForumForm.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIForumForm.java
@@ -144,7 +144,7 @@ public class UIForumForm extends BaseForumForm implements UIPopupComponent {
     forum = new Forum();
     List<SelectItemOption<String>> list = new ArrayList<SelectItemOption<String>>();
     if (ForumUtils.isEmpty(categoryId)) {
-      List<Category> categorys = getForumService().getCategories();
+      List<Category> categorys = getForumService().getCategoriesForumCreation();
       for (Category category : categorys) {
         list.add(new SelectItemOption<String>(category.getCategoryName(), category.getId()));
       }

--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIForumForm.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UIForumForm.java
@@ -144,7 +144,7 @@ public class UIForumForm extends BaseForumForm implements UIPopupComponent {
     forum = new Forum();
     List<SelectItemOption<String>> list = new ArrayList<SelectItemOption<String>>();
     if (ForumUtils.isEmpty(categoryId)) {
-      List<Category> categorys = getForumService().getCategoriesForumCreation();
+      List<Category> categorys = getForumService().getCategories(true);
       for (Category category : categorys) {
         list.add(new SelectItemOption<String>(category.getCategoryName(), category.getId()));
       }


### PR DESCRIPTION
Fix description : 
1. Don't allow forum creation in the "Spaces" category when we have only this category in the list. 
2. remove the "Spaces" category from the select field  when creating a new forum in the case when some categories exist.