### PR TITLE
FORUM-1244: Cannot access forum of space newly created

### DIFF
--- a/forum/service/src/main/java/org/exoplatform/forum/service/cache/CachedDataStorage.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/cache/CachedDataStorage.java
@@ -764,6 +764,7 @@ public class CachedDataStorage implements DataStorage, Startable {
     clearForumListCache();
     clearLinkListCache();
     clearObjectCache(forum, true);
+    clearCategoryCache(categoryId);
     //
     clearTopicListCache(forum.getId());
     clearTopicListCountCache(forum.getId());


### PR DESCRIPTION
Fix Decscription:
- Clear Category Data cache that contains permissions map to add the newly created space